### PR TITLE
Add Universidad Tecnológica del Perú (utp.edu.pe) to JetBrains/swot

### DIFF
--- a/lib/domains/pe/edu/utp.txt
+++ b/lib/domains/pe/edu/utp.txt
@@ -1,0 +1,2 @@
+Universidad Tecnológica del Perú  
+Technological University of Peru


### PR DESCRIPTION
🇬🇧 Adding Universidad Tecnológica del Perú (UTP), a Peruvian higher education institution that offers long-term programs in software engineering, computer science, and other IT-related fields. 

- Official website: https://www.utp.edu.pe
- The email domain `utp.edu.pe` is officially used by students and faculty.

This request aims to include the domain `utp.edu.pe` to allow students and professors from UTP to access JetBrains educational licenses.

🇪🇸 Se agrega la Universidad Tecnológica del Perú (UTP), una institución peruana de educación superior que ofrece carreras de larga duración en ingeniería de software, ciencias de la computación y otras áreas relacionadas a TI.

- Sitio web oficial: https://www.utp.edu.pe
- El dominio de correo `utp.edu.pe` es usado oficialmente por estudiantes y docentes.

Esta solicitud busca incluir el dominio `utp.edu.pe` para que los estudiantes y profesores de la UTP puedan acceder a licencias educativas de JetBrains.